### PR TITLE
iterate over files to when loading data during initialize_app

### DIFF
--- a/chirps/base_app/management/commands/initialize_app.py
+++ b/chirps/base_app/management/commands/initialize_app.py
@@ -1,10 +1,11 @@
 """Management command to initialize the app by running multiple management commands in succession."""
 import os
 
-from chirps.settings import BASE_DIR
 from django.contrib.auth.models import User
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
+
+from chirps.settings import BASE_DIR
 
 
 class Command(BaseCommand):

--- a/chirps/base_app/tests.py
+++ b/chirps/base_app/tests.py
@@ -1,10 +1,15 @@
 """Tests for the base application."""
 from django.test import TestCase
-from .management.commands.initialize_app import Command
 from plan.models import Plan
 
+from .management.commands.initialize_app import Command
+
+
 class InitializeAppTests(TestCase):
+    """Test the initialize_app management command"""
+
     def test_load_data_from_plans_directory(self):
+        """Test that data is loaded"""
         assert Plan.objects.count() == 0
         command = Command()
         command.load_data_from_plans_directory()


### PR DESCRIPTION
The purpose of this PR is to remove the hardcoded file path used to load plan data when the `./manage.py initialize_app` command is executed. Now we'll iterate over the files and load the data from each.