### PR TITLE
Fixing an embedding query bug

### DIFF
--- a/chirps/embedding/admin.py
+++ b/chirps/embedding/admin.py
@@ -3,4 +3,4 @@ from django.contrib import admin
 
 from .models import Embedding
 
-admin.register(Embedding)
+admin.site.register(Embedding)


### PR DESCRIPTION
When a user-cloned policy is used, it needs to search the embedding cache for both user-defined embeddings, as well as any that were created for the templates. The embeddings created by for templates do NOT have a user associated with them, hence the usage of the Django Query object. 

Closes out issue #97 