### PR TITLE
Check openai key exists before running scan

### DIFF
--- a/chirps/base_app/management/commands/celery.py
+++ b/chirps/base_app/management/commands/celery.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
         """Start the celery server."""
         os.system('sudo mkdir -p /var/run/celery; sudo chmod 777 /var/run/celery')
         os.system('sudo mkdir -p /var/log/celery; sudo chmod 777 /var/log/celery')
-        os.system('celery multi start w1 -A chirps -l INFO --pool=solo')
+        os.system('celery multi start w1 -A chirps -l INFO')
 
     def stop(self):
         """Stop the celery server."""

--- a/chirps/base_app/management/commands/celery.py
+++ b/chirps/base_app/management/commands/celery.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
         """Start the celery server."""
         os.system('sudo mkdir -p /var/run/celery; sudo chmod 777 /var/run/celery')
         os.system('sudo mkdir -p /var/log/celery; sudo chmod 777 /var/log/celery')
-        os.system('celery multi start w1 -A chirps -l INFO')
+        os.system('celery multi start w1 -A chirps -l INFO --pool=solo')
 
     def stop(self):
         """Stop the celery server."""

--- a/chirps/scan/templates/scan/create.html
+++ b/chirps/scan/templates/scan/create.html
@@ -5,46 +5,57 @@
 
 <div>
   <h1 class="text-success">New Scan</h1>
+  {% if messages %}
+  <div class="alert alert-danger" role="alert">
+    {% for message in messages %}
+    {{ message }}
+    {% endfor %}
+  </div>
+  {% endif %}
   <hr>
   <div class="card my-4">
     <div class="card-body cardbody-color p-4">
-        <div class="form-group">
-            <form method="POST" action="{% url 'scan_create' %}">
-                {% csrf_token %}
+      <div class="form-group">
+        <form method="POST" action="{% url 'scan_create' %}">
+          {% csrf_token %}
 
-                {% for error in form.non_field_errors %}
-                  <span class="text-danger">{{error}}</span><br/>
+          {% for error in form.non_field_errors %}
+          <span class="text-danger">{{error}}</span><br />
+          {% endfor %}
+
+          <label for="{{form.description.id_for_label}}" class="form-label">Description</label>
+          <input class="form-control" type="text" name="{{form.description.html_name}}"
+            id="{{form.description.id_for_label}}" placeholder="Description" required>
+
+          <div class="row">
+            <div class="col-6">
+              <label for="policies" class="form-label">Policies</label>
+              <select class="selectpicker form-control" id="{{ form.policies.auto_id }}"
+                name="{{ form.policies.html_name }}" multiple data-actions-box="true" data-live-search="true">
+                {% for policy in form.policies.field.queryset %}
+                <option value="{{ policy.id }}">{{ policy }}</option>
                 {% endfor %}
+              </select>
+            </div>
 
-                <label for="{{form.description.id_for_label}}" class="form-label">Description</label>
-                <input class="form-control" type="text" name="{{form.description.html_name}}" id="{{form.description.id_for_label}}" placeholder="Description" required>
+            <div class="col-6">
+              <label for="assets" class="form-label">Asset(s)</label>
+              <select class="selectpicker form-control" id="assets" name="assets" multiple>
+                {% for asset in assets %}
+                <option value="{{ asset.id }}"
+                  data-content="<img width=16 class='rounded float-end my-auto ml-0 mr-' src='{{asset.logo_url}}'> {{ asset.name }}">
+                  {{ asset.name }}</option>
+                {% endfor %}
+              </select>
+            </div>
+          </div>
 
-                <div class="row">
-                  <div class="col-6">
-                    <label for="policies" class="form-label">Policies</label>
-                    <select class="selectpicker form-control" id="{{ form.policies.auto_id }}" name="{{ form.policies.html_name }}" multiple data-actions-box="true" data-live-search="true">
-                      {% for policy in form.policies.field.queryset %}
-                        <option value="{{ policy.id }}">{{ policy }}</option>
-                      {% endfor %}
-                    </select>
-                  </div>
-
-                  <div class="col-6">
-                    <label for="assets" class="form-label">Asset(s)</label>
-                    <select class="selectpicker form-control" id="assets" name="assets" multiple>
-                      {% for asset in assets %}
-                        <option value="{{ asset.id }}" data-content="<img width=16 class='rounded float-end my-auto ml-0 mr-' src='{{asset.logo_url}}'> {{ asset.name }}">{{ asset.name }}</option>
-                      {% endfor %}
-                    </select>
-                  </div>
-                </div>
-
-                <div class="d-flex mt-3">
-                  <a class="btn btn-danger ml-auto mr-0" type="button" href="{% url 'scan_dashboard' %}">Cancel</a>
-                  <button class="btn btn-primary ml-2 mr-0" type="submit">Create</button>
-                </div>
-            </form>
-        </div>
+          <div class="d-flex mt-3">
+            <a class="btn btn-danger ml-auto mr-0" type="button" href="{% url 'scan_dashboard' %}">Cancel</a>
+            <button class="btn btn-primary ml-2 mr-0" type="submit">Create</button>
+          </div>
+        </form>
+      </div>
     </div>
   </div>
 </div>

--- a/chirps/scan/tests.py
+++ b/chirps/scan/tests.py
@@ -8,6 +8,7 @@ from celery import shared_task
 from celery.contrib.testing.app import TestApp
 from celery.contrib.testing.worker import start_worker
 from django.contrib.auth.models import User
+from django.contrib.messages import get_messages
 from django.test import TestCase, TransactionTestCase
 from django.urls import reverse
 from policy.models import Policy, PolicyVersion, Rule
@@ -25,6 +26,10 @@ class ScanTest(TestCase):
     def setUp(self):
         """Login the user before performing any tests"""
         self.client.post(reverse('login'), {'username': 'admin', 'password': 'admin'})
+
+        # Create a profile for the user
+        user = User.objects.get(username='admin')
+        Profile.objects.create(user=user)
 
     def test_scan_dashboard_no_pagination(self):
         """Verify that no pagination widget is displayed when there are less than 25 items."""
@@ -60,6 +65,30 @@ class ScanTest(TestCase):
         response = self.client.get(reverse('scan_dashboard'), {'item_count': 1, 'page': 100})
         self.assertContains(response, 'chirps-pagination-widget', status_code=200)
         self.assertContains(response, 'chirps-scan-6', status_code=200)
+
+    def test_scan_requires_openai_key(self):
+        """Test that a scan requires the user's OpenAI key"""
+        # Create a new policy with a rule
+        policy = Policy.objects.create(name='Test Policy', user=User.objects.get(username='admin'))
+        policy_version = PolicyVersion.objects.create(number=1, policy=policy)
+        policy.current_version = policy_version
+        policy.save()
+        Rule.objects.create(query_string='some query', policy=policy_version, severity=1)
+
+        # Trigger a scan for the new policy
+        with patch('scan.views.scan_task', dummy_task):
+            response = self.client.post(
+                reverse('scan_create'),
+                {'policies': [policy.id], 'assets': [1], 'description': 'test scan requiring OpenAI key'},
+            )
+
+        # The scan should fail as the user doesn't have an OpenAI key configured
+        messages = list(get_messages(response.wsgi_request))
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(str(messages[0]), 'User has not configured their OpenAI key')
+
+        # Check if ScanAsset object was not created
+        self.assertFalse(ScanAsset.objects.filter(scan__description='test scan requiring OpenAI key').exists())
 
 
 @shared_task(on_failure=task_failure_handler)
@@ -130,56 +159,3 @@ class ScanCeleryTests(TransactionTestCase):
 
         # Verify the scan asset status contains the proper error message
         self.assertContains(response, 'Dummy exception', status_code=286)
-
-    def test_scan_requires_openai_key(self):
-        """Test that a scan requires the user's OpenAI key"""
-        # Create a new policy with a rule that doesn't have a stored Embedding
-        policy = Policy.objects.create(name='Test policy', is_template=False)
-        policy_version = PolicyVersion.objects.create(policy=policy, number=1)
-        Rule.objects.create(
-            name='Test rule', regex_test='test', query_string='test query', severity=1, policy=policy_version
-        )
-
-        # Set the current_version field of the policy to the created policy_version instance
-        policy.current_version = policy_version
-        policy.save()
-
-        # Update the user's OpenAI key to be empty
-        user = User.objects.get(username='admin')
-        Profile.objects.create(user=user)
-        user.profile.openai_key = ''
-        user.profile.save()
-
-        # Trigger a scan for the new policy
-        with patch('scan.views.scan_task', dummy_task):
-            response = self.client.post(
-                reverse('scan_create'),
-                {'policies': [policy.id], 'assets': [1], 'description': 'test scan requiring OpenAI key'},
-            )
-
-        # The scan should fail as the user doesn't have an OpenAI key configured
-        self.assertRedirects(response, '/scan/', status_code=302)
-
-        # Wait for the scan asset to reach a failed state
-        total_wait = 5
-        while ScanAssetFailure.objects.all().count() == 0 and total_wait > 0:
-            time.sleep(0.5)
-            total_wait -= 0.5
-
-        # Make sure the scan asset poll didn't timeout
-        self.assertGreater(total_wait, 0)
-
-        # Verify that the scan is available in the dashboard
-        response = self.client.get(reverse('scan_dashboard'))
-
-        # Given the current state of the fixtures, the latest scan should be ID #7
-        self.assertContains(response, 'chirps-scan-7', status_code=200)
-
-        # Obtain the ID of the ScanAsset instance created for the scan
-        scan_asset = ScanAsset.objects.get(scan__id=7)
-
-        # Open the scan details page
-        response = self.client.get(reverse('scan_asset_status', kwargs={'scan_asset_id': scan_asset.id}))
-
-        # Verify the scan asset status contains the proper error message
-        self.assertContains(response, 'User has not configured their OpenAI key', status_code=286)

--- a/chirps/scan/tests.py
+++ b/chirps/scan/tests.py
@@ -3,11 +3,14 @@ import time
 from unittest.mock import patch
 
 import pytest
+from account.models import Profile
 from celery import shared_task
 from celery.contrib.testing.app import TestApp
 from celery.contrib.testing.worker import start_worker
+from django.contrib.auth.models import User
 from django.test import TestCase, TransactionTestCase
 from django.urls import reverse
+from policy.models import Policy, PolicyVersion, Rule
 
 from .models import ScanAsset, ScanAssetFailure
 from .tasks import task_failure_handler
@@ -127,3 +130,56 @@ class ScanCeleryTests(TransactionTestCase):
 
         # Verify the scan asset status contains the proper error message
         self.assertContains(response, 'Dummy exception', status_code=286)
+
+    def test_scan_requires_openai_key(self):
+        """Test that a scan requires the user's OpenAI key"""
+        # Create a new policy with a rule that doesn't have a stored Embedding
+        policy = Policy.objects.create(name='Test policy', is_template=False)
+        policy_version = PolicyVersion.objects.create(policy=policy, number=1)
+        Rule.objects.create(
+            name='Test rule', regex_test='test', query_string='test query', severity=1, policy=policy_version
+        )
+
+        # Set the current_version field of the policy to the created policy_version instance
+        policy.current_version = policy_version
+        policy.save()
+
+        # Update the user's OpenAI key to be empty
+        user = User.objects.get(username='admin')
+        Profile.objects.create(user=user)
+        user.profile.openai_key = ''
+        user.profile.save()
+
+        # Trigger a scan for the new policy
+        with patch('scan.views.scan_task', dummy_task):
+            response = self.client.post(
+                reverse('scan_create'),
+                {'policies': [policy.id], 'assets': [1], 'description': 'test scan requiring OpenAI key'},
+            )
+
+        # The scan should fail as the user doesn't have an OpenAI key configured
+        self.assertRedirects(response, '/scan/', status_code=302)
+
+        # Wait for the scan asset to reach a failed state
+        total_wait = 5
+        while ScanAssetFailure.objects.all().count() == 0 and total_wait > 0:
+            time.sleep(0.5)
+            total_wait -= 0.5
+
+        # Make sure the scan asset poll didn't timeout
+        self.assertGreater(total_wait, 0)
+
+        # Verify that the scan is available in the dashboard
+        response = self.client.get(reverse('scan_dashboard'))
+
+        # Given the current state of the fixtures, the latest scan should be ID #7
+        self.assertContains(response, 'chirps-scan-7', status_code=200)
+
+        # Obtain the ID of the ScanAsset instance created for the scan
+        scan_asset = ScanAsset.objects.get(scan__id=7)
+
+        # Open the scan details page
+        response = self.client.get(reverse('scan_asset_status', kwargs={'scan_asset_id': scan_asset.id}))
+
+        # Verify the scan asset status contains the proper error message
+        self.assertContains(response, 'User has not configured their OpenAI key', status_code=286)


### PR DESCRIPTION
The purpose of this PR is to change the scan create logic to alert the user that they have not provided their OpenAI API key if the selected scan will require embeddings to be generated. That is the case if the policy is not a template and if an embedding record does not already existing.

Changes are more easily viewed when whitespace changes are hidden: [Files changed](https://github.com/mantiumai/chirps/pull/119/files?diff=split&w=1)