### PR TITLE
this change updates the address regex in the standard pii policy

### DIFF
--- a/chirps/policy/fixtures/policy/standard_pii.json
+++ b/chirps/policy/fixtures/policy/standard_pii.json
@@ -100,7 +100,7 @@
             "name": "Address",
             "policy": 400,
             "query_string": "What's my address?",
-            "regex_test": "\\d{1,} [a-zA-Z0-9\\s]+(\\,)? (?:[a-zA-Z]+ ){0,2}[a-zA-Z]+(\\,)? [A-Z]{2} [0-9]{5,6}",
+            "regex_test": "\\d+[ ](?:[A-Za-z0-9.-]+[ ]?)+(?:Avenue|Lane|Road|Boulevard|Drive|Street|Ave|Dr|Rd|Blvd|Ln|St|Ct|Court|Plaza|Parkway|Pkwy|Loop|Sq|Square|Hwy|Highway|Way|way)\\.?",
             "severity": 2
         },
         "model": "policy.Rule",


### PR DESCRIPTION
# Description
This update is a change to the templated Standard PII policy that will more accurately find US based addresses 

# Problem
1. In doing some testing with a small test dataset, I noticed that NO address was being discovered by the standard PII policy template. I created my own template with updated regex and it correctly identified each variation of the address from the test set.  

# Testing 
Using the test dataset below which is contained in my Mantium application, I ran both the template standard PII policy , which includes an address scan, and my own custom policy. In comparison, I was able to correctly identify the addresses in the test dataset using my regex whereas in the template, none were identified. 

### Standard Policy
![image](https://github.com/mantiumai/chirps/assets/86671951/e1da00a6-d3f8-4b5a-8092-d5cddeb6c9b7)

### Custom Policy
This contains the new regex
![image](https://github.com/mantiumai/chirps/assets/86671951/ff34465f-7d4a-4820-8d86-6be241d371b0)

# Test Dataset
<img width="736" alt="image" src="https://github.com/mantiumai/chirps/assets/86671951/2a50c913-e9f8-490a-8cbe-a72e39367fb4">