### PR TITLE
Display worker status

### DIFF
--- a/chirps/base_app/templates/base.html
+++ b/chirps/base_app/templates/base.html
@@ -16,10 +16,6 @@
     <body>
         <div>
             {% include 'header.html' %}
-            <!-- Add the worker status indicator in the navbar -->
-            <div id="worker-status" hx-get="/worker/status/" hx-trigger="every 5s" style="float: right; margin-right: 20px;">
-            <!-- Initial status indicator will be loaded here -->
-            </div>
             <div class="container mt-3">
                 {% block content%}{%endblock%}
             </div>

--- a/chirps/base_app/templates/base.html
+++ b/chirps/base_app/templates/base.html
@@ -16,6 +16,10 @@
     <body>
         <div>
             {% include 'header.html' %}
+            <!-- Add the worker status indicator in the navbar -->
+            <div id="worker-status" hx-get="/worker/status/" hx-trigger="every 5s" style="float: right; margin-right: 20px;">
+            <!-- Initial status indicator will be loaded here -->
+            </div>
             <div class="container mt-3">
                 {% block content%}{%endblock%}
             </div>

--- a/chirps/base_app/templates/header.html
+++ b/chirps/base_app/templates/header.html
@@ -1,15 +1,29 @@
 {% load static %}
+<style>
+.worker-status-indicator {
+  display: inline-block;
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+}
+</style>
 <div>
     <nav class="navbar navbar-light navbar-expand-lg bg-light w-100">
-        <div class="container-fluid">
-            <a class="navbar-brand" href="/"><img src="{% static 'account/chirps_logo.png' %}" width="32"></a>
-            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-                <span class="navbar-toggler-icon"></span>
-            </button>
+        <div class="container-fluid d-flex justify-content-between">
+            <div>
+                <a class="navbar-brand" href="/"><img src="{% static 'account/chirps_logo.png' %}" width="32"></a>
+                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
+            </div>
+
+            <!-- Status indicator -->
+            <div id="worker-status">
+                <div class="worker-status-indicator" style="background-color: green;"></div>
+            </div>
 
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-
                   <li class="nav-item">
                     <a class="nav-link" aria-current="page" href="{% url 'asset_dashboard' %}"><i class="fa-solid fa-bullseye"></i> Assets</i></a>
                   </li>
@@ -23,7 +37,6 @@
                   </li>
 
                   {% if user.is_authenticated %}
-
                   <li class="nav-item">
                     <a class="nav-link" aria-current="page" href="{% url 'profile' %}"><i class="fa-regular fa-circle-user"></i> Account</a>
                   </li>
@@ -43,3 +56,19 @@
         </div>
     </nav>
 </div>
+
+<script>
+  function updateStatusIndicator() {
+    fetch('/worker/status/')
+      .then(response => response.json())
+      .then(data => {
+        let status = data.status;
+        let indicator = document.querySelector("#worker-status .worker-status-indicator");
+        indicator.style.backgroundColor = status;
+      })
+      .catch(error => console.error(error));
+  }
+
+  // Update the status indicator every 5 seconds
+  setInterval(updateStatusIndicator, 5000);
+  </script>

--- a/chirps/base_app/templates/header.html
+++ b/chirps/base_app/templates/header.html
@@ -57,7 +57,7 @@
       </div>
       <!-- Status indicator -->
       <div class="ms-auto">
-        <div id="worker-status" hx-get="/worker/status/" hx-trigger="every 5s" hx-swap="none">
+        <div id="worker-status" hx-get="/worker/status/" hx-trigger="load, every 5s" hx-swap="none">
           <div class="worker-status-indicator" title="Worker status" hx-trigger="click"
             hx-swap="none"></div>
         </div>

--- a/chirps/base_app/templates/header.html
+++ b/chirps/base_app/templates/header.html
@@ -58,7 +58,7 @@
       <!-- Status indicator -->
       <div class="ms-auto">
         <div id="worker-status" hx-get="/worker/status/" hx-trigger="every 5s" hx-swap="none">
-          <div class="worker-status-indicator" style="background-color: green;" title="Worker status" hx-trigger="click"
+          <div class="worker-status-indicator" title="Worker status" hx-trigger="click"
             hx-swap="none"></div>
         </div>
       </div>

--- a/chirps/base_app/templates/header.html
+++ b/chirps/base_app/templates/header.html
@@ -56,11 +56,12 @@
         </ul>
       </div>
       <!-- Status indicator -->
-<div class="ms-auto">
-  <div id="worker-status" hx-get="/worker/status/" hx-trigger="every 5s" hx-swap="none">
-    <div class="worker-status-indicator" style="background-color: green;" title="Worker status" hx-trigger="click" hx-swap="none"></div>
-  </div>
-</div>
+      <div class="ms-auto">
+        <div id="worker-status" hx-get="/worker/status/" hx-trigger="every 5s" hx-swap="none">
+          <div class="worker-status-indicator" style="background-color: green;" title="Worker status" hx-trigger="click"
+            hx-swap="none"></div>
+        </div>
+      </div>
     </div>
   </nav>
 </div>

--- a/chirps/base_app/templates/header.html
+++ b/chirps/base_app/templates/header.html
@@ -2,8 +2,8 @@
 <style>
   .worker-status-indicator {
     display: inline-block;
-    width: 15px;
-    height: 15px;
+    width: 20px;
+    height: 20px;
     border-radius: 50%;
   }
 </style>

--- a/chirps/base_app/templates/header.html
+++ b/chirps/base_app/templates/header.html
@@ -1,74 +1,85 @@
 {% load static %}
 <style>
-.worker-status-indicator {
-  display: inline-block;
-  width: 15px;
-  height: 15px;
-  border-radius: 50%;
-}
+  .worker-status-indicator {
+    display: inline-block;
+    width: 15px;
+    height: 15px;
+    border-radius: 50%;
+  }
 </style>
 <div>
-    <nav class="navbar navbar-light navbar-expand-lg bg-light w-100">
-        <div class="container-fluid d-flex justify-content-between">
-            <div>
-                <a class="navbar-brand" href="/"><img src="{% static 'account/chirps_logo.png' %}" width="32"></a>
-                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-                    <span class="navbar-toggler-icon"></span>
-                </button>
-            </div>
+  <nav class="navbar navbar-light navbar-expand-lg bg-light w-100">
+    <div class="container-fluid d-flex justify-content-between">
+      <div>
+        <a class="navbar-brand" href="/"><img src="{% static 'account/chirps_logo.png' %}" width="32"></a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
+          aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+      </div>
 
-            <!-- Status indicator -->
-            <div id="worker-status">
-                <div class="worker-status-indicator" style="background-color: green;"></div>
-            </div>
+      <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+          <li class="nav-item">
+            <a class="nav-link" aria-current="page" href="{% url 'asset_dashboard' %}"><i
+                class="fa-solid fa-bullseye"></i> Assets</i></a>
+          </li>
 
-            <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-                  <li class="nav-item">
-                    <a class="nav-link" aria-current="page" href="{% url 'asset_dashboard' %}"><i class="fa-solid fa-bullseye"></i> Assets</i></a>
-                  </li>
+          <li class="nav-item">
+            <a class="nav-link" aria-current="page" href="{% url 'policy_dashboard' %}"><i class="fa-solid fa-map"></i>
+              Policies</a>
+          </li>
 
-                  <li class="nav-item">
-                    <a class="nav-link" aria-current="page"href="{% url 'policy_dashboard' %}"><i class="fa-solid fa-map"></i> Policies</a>
-                  </li>
+          <li class="nav-item">
+            <a class="nav-link" aria-current="page" href="{% url 'scan_dashboard' %}"><i
+                class="fa-solid fa-magnifying-glass"></i> Scans</a>
+          </li>
 
-                  <li class="nav-item">
-                    <a class="nav-link" aria-current="page" href="{% url 'scan_dashboard' %}"><i class="fa-solid fa-magnifying-glass"></i> Scans</a>
-                  </li>
+          {% if user.is_authenticated %}
+          <li class="nav-item">
+            <a class="nav-link" aria-current="page" href="{% url 'profile' %}"><i class="fa-regular fa-circle-user"></i>
+              Account</a>
+          </li>
 
-                  {% if user.is_authenticated %}
-                  <li class="nav-item">
-                    <a class="nav-link" aria-current="page" href="{% url 'profile' %}"><i class="fa-regular fa-circle-user"></i> Account</a>
-                  </li>
+          <li class="nav-item">
+            <a class="nav-link" aria-current="page" href="{% url 'logout' %}"><i
+                class="fa-solid fa-arrow-right-from-bracket"></i> Logout</a>
+          </li>
+          {% endif %}
 
-                  <li class="nav-item">
-                    <a class="nav-link" aria-current="page" href="{% url 'logout' %}"><i class="fa-solid fa-arrow-right-from-bracket"></i> Logout</a>
-                  </li>
-                  {% endif %}
-
-                  {% if user.is_superuser %}
-                  <li class="nav-item">
-                    <a class="nav-link" aria-current="page" href="{% url 'admin:index' %}"><i class="fa-solid fa-user-ninja"></i> Admin</a>
-                  </li>
-                  {% endif %}
-                </ul>
-            </div>
+          {% if user.is_superuser %}
+          <li class="nav-item">
+            <a class="nav-link" aria-current="page" href="{% url 'admin:index' %}"><i
+                class="fa-solid fa-user-ninja"></i> Admin</a>
+          </li>
+          {% endif %}
+        </ul>
+      </div>
+      <!-- Status indicator -->
+      <div class="ms-auto">
+        <div id="worker-status" hx-get="/worker/status/" hx-trigger="every 5s" hx-swap="none">Worker status:
+          <div class="worker-status-indicator" style="background-color: green;"></div>
         </div>
-    </nav>
+      </div>
+    </div>
+  </nav>
 </div>
 
 <script>
-  function updateStatusIndicator() {
-    fetch('/worker/status/')
-      .then(response => response.json())
-      .then(data => {
-        let status = data.status;
+  document.body.addEventListener('htmx:configRequest', function (event) {
+    if (event.target.id === 'worker-status') {
+      event.detail.headers['HX-Response-Content-Type'] = 'application/json';
+    }
+  });
+
+  document.body.addEventListener('htmx:afterSwap', function (event) {
+    if (event.target.id === 'worker-status') {
+      let xhr = event.detail.xhr;
+      if (xhr) {
+        let status = JSON.parse(xhr.responseText).status;
         let indicator = document.querySelector("#worker-status .worker-status-indicator");
         indicator.style.backgroundColor = status;
-      })
-      .catch(error => console.error(error));
-  }
-
-  // Update the status indicator every 5 seconds
-  setInterval(updateStatusIndicator, 5000);
-  </script>
+      }
+    }
+  });
+</script>

--- a/chirps/base_app/templates/header.html
+++ b/chirps/base_app/templates/header.html
@@ -56,13 +56,32 @@
         </ul>
       </div>
       <!-- Status indicator -->
-      <div class="ms-auto">
-        <div id="worker-status" hx-get="/worker/status/" hx-trigger="every 5s" hx-swap="none">Worker status:
-          <div class="worker-status-indicator" style="background-color: green;"></div>
-        </div>
-      </div>
+<div class="ms-auto">
+  <div id="worker-status" hx-get="/worker/status/" hx-trigger="every 5s" hx-swap="none">
+    <div class="worker-status-indicator" style="background-color: green;" title="Worker status" hx-trigger="click" hx-swap="none"></div>
+  </div>
+</div>
     </div>
   </nav>
+</div>
+
+<!-- Status Details Modal -->
+<div class="modal fade" id="statusDetailsModal" tabindex="-1" aria-labelledby="statusDetailsModalLabel"
+  aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="statusDetailsModalLabel">Worker Status Details</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body" id="statusDetailsModalBody">
+        <!-- Status details will be displayed here -->
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
 </div>
 
 <script>
@@ -76,10 +95,40 @@
     if (event.target.id === 'worker-status') {
       let xhr = event.detail.xhr;
       if (xhr) {
-        let status = JSON.parse(xhr.responseText).status;
+        let response = JSON.parse(xhr.responseText);
+        let overallStatus = response.overall_status;
+        let serviceStatuses = response.service_statuses;
         let indicator = document.querySelector("#worker-status .worker-status-indicator");
-        indicator.style.backgroundColor = status;
+        indicator.style.backgroundColor = overallStatus;
+        indicator.setAttribute('title', 'Click to see service statuses');
+
+        // Store the service statuses in the indicator element for later use
+        indicator.dataset.serviceStatuses = JSON.stringify(serviceStatuses);
       }
+    }
+  });
+
+  document.addEventListener('DOMContentLoaded', function () {
+    let indicator = document.querySelector("#worker-status .worker-status-indicator");
+  });
+
+  document.addEventListener('click', function (event) {
+    let indicator = document.querySelector("#worker-status .worker-status-indicator");
+    if (event.target === indicator) {
+      let serviceStatuses = JSON.parse(indicator.dataset.serviceStatuses);
+
+      let statusesHTML = '';
+      for (const [service, status] of Object.entries(serviceStatuses)) {
+        statusesHTML += `<p><strong>${service} status:</strong> ${status ? 'Online' : 'Offline'}</p>`;
+      }
+
+      // Display the service statuses in the modal body
+      let modalBody = document.getElementById('statusDetailsModalBody');
+      modalBody.innerHTML = statusesHTML;
+
+      // Show the modal
+      let statusDetailsModal = new bootstrap.Modal(document.getElementById('statusDetailsModal'));
+      statusDetailsModal.show();
     }
   });
 </script>

--- a/chirps/chirps/settings.py
+++ b/chirps/chirps/settings.py
@@ -55,6 +55,7 @@ INSTALLED_APPS = [
     'account',
     'policy',
     'embedding',
+    'worker',
 ]
 
 MIDDLEWARE = [

--- a/chirps/chirps/urls.py
+++ b/chirps/chirps/urls.py
@@ -26,4 +26,5 @@ urlpatterns = [
     path('policy/', include('policy.urls')),
     path('scan/', include('scan.urls')),
     path('asset/', include('asset.urls')),
+    path('worker/', include('worker.urls')),
 ]

--- a/chirps/worker/apps.py
+++ b/chirps/worker/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class WorkerConfig(AppConfig):
+    """Worker application config"""
+
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'worker'

--- a/chirps/worker/apps.py
+++ b/chirps/worker/apps.py
@@ -1,3 +1,4 @@
+"""Worker application apps"""
 from django.apps import AppConfig
 
 

--- a/chirps/worker/tests.py
+++ b/chirps/worker/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/chirps/worker/tests.py
+++ b/chirps/worker/tests.py
@@ -12,31 +12,37 @@ class WorkerStatusViewTests(TestCase):
         self.client = Client()
 
     @patch('worker.views.app')
+    @patch('worker.views.is_redis_running')
     @patch('worker.views.os')
-    def test_worker_status_green(self, mock_os, mock_app):
+    def test_worker_status_green(self, mock_os, mock_is_redis_running, mock_app):
         """Test response when services are running"""
-        # Mock the Celery worker and RabbitMQ statuses to be running
+        # Mock the Celery worker, RabbitMQ, and Redis statuses to be running
         mock_app.control.inspect.return_value.ping.return_value = {'worker1': {'ok': 'pong'}}
         mock_os.system.return_value = 0
+        mock_is_redis_running.return_value = True
 
         response = self.client.get('/worker/status/')
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response.json(), {'overall_status': 'green', 'service_statuses': {'celery': True, 'rabbitmq': True}}
+            response.json(),
+            {'overall_status': 'green', 'service_statuses': {'celery': True, 'rabbitmq': True, 'redis': True}},
         )
 
     @patch('worker.views.app')
+    @patch('worker.views.is_redis_running')
     @patch('worker.views.os')
-    def test_worker_status_red(self, mock_os, mock_app):
+    def test_worker_status_red(self, mock_os, mock_is_redis_running, mock_app):
         """Test response when services are not running"""
-        # Mock the Celery worker and RabbitMQ statuses to be not running
+        # Mock the Celery worker, RabbitMQ, and Redis statuses to be not running
         mock_app.control.inspect.return_value.ping.return_value = None
         mock_os.system.return_value = 1
+        mock_is_redis_running.return_value = False
 
         response = self.client.get('/worker/status/')
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response.json(), {'overall_status': 'red', 'service_statuses': {'celery': False, 'rabbitmq': False}}
+            response.json(),
+            {'overall_status': 'red', 'service_statuses': {'celery': False, 'rabbitmq': False, 'redis': False}},
         )

--- a/chirps/worker/tests.py
+++ b/chirps/worker/tests.py
@@ -1,3 +1,41 @@
-from django.test import TestCase
+from unittest.mock import patch
 
-# Create your tests here.
+from django.test import Client, TestCase
+
+
+class WorkerStatusViewTests(TestCase):
+    """Tests of the worker status view"""
+
+    def setUp(self):
+        """Test setup"""
+        self.client = Client()
+
+    @patch('worker.views.app')
+    @patch('worker.views.os')
+    def test_worker_status_green(self, mock_os, mock_app):
+        """Test response when services are running"""
+        # Mock the Celery worker and RabbitMQ statuses to be running
+        mock_app.control.inspect.return_value.ping.return_value = {'worker1': {'ok': 'pong'}}
+        mock_os.system.return_value = 0
+
+        response = self.client.get('/worker/status/')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(), {'overall_status': 'green', 'service_statuses': {'celery': True, 'rabbitmq': True}}
+        )
+
+    @patch('worker.views.app')
+    @patch('worker.views.os')
+    def test_worker_status_red(self, mock_os, mock_app):
+        """Test response when services are not running"""
+        # Mock the Celery worker and RabbitMQ statuses to be not running
+        mock_app.control.inspect.return_value.ping.return_value = None
+        mock_os.system.return_value = 1
+
+        response = self.client.get('/worker/status/')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(), {'overall_status': 'red', 'service_statuses': {'celery': False, 'rabbitmq': False}}
+        )

--- a/chirps/worker/tests.py
+++ b/chirps/worker/tests.py
@@ -1,3 +1,4 @@
+"""worker application tests"""
 from unittest.mock import patch
 
 from django.test import Client, TestCase

--- a/chirps/worker/urls.py
+++ b/chirps/worker/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    path('status/', views.worker_status, name='worker_status'),
+]

--- a/chirps/worker/urls.py
+++ b/chirps/worker/urls.py
@@ -1,3 +1,4 @@
+"""Worker application URLs"""
 from django.urls import path
 
 from . import views

--- a/chirps/worker/views.py
+++ b/chirps/worker/views.py
@@ -1,18 +1,16 @@
-from django.http import HttpResponse
+from django.http import JsonResponse
 
 from chirps.celery import app
 
 
 def worker_status(request):
-    """Get the worker's status"""
-    inspection = app.control.inspect()  # Use app.control.inspect() instead of app.inspect()
+    """Get the status of the Celery worker"""
+    inspection = app.control.inspect()
     result = inspection.ping()
 
     if result:
-        color = 'green'
+        status = 'green'
     else:
-        color = 'red'
+        status = 'red'
 
-    return HttpResponse(
-        f'<div style="display: inline-block; width: 15px; height: 15px; border-radius: 50%; background-color: {color};"></div>'
-    )
+    return JsonResponse({'status': status})

--- a/chirps/worker/views.py
+++ b/chirps/worker/views.py
@@ -12,14 +12,14 @@ def is_redis_running() -> bool:
     """Check redis status"""
     cmd = 'docker-compose -f /workspace/.devcontainer/docker-compose.yml ps | grep redis'
     try:
-        result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, text=True)
-    except Exception:
+        result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, text=True, check=True)
+    except Exception:   # type: ignore
         return False
-    else:
-        if result.returncode == 0 and 'redis' in result.stdout and 'Up' in result.stdout:
-            return True
-        else:
-            return False
+
+    if result.returncode == 0 and 'redis' in result.stdout and 'Up' in result.stdout:
+        return True
+
+    return False
 
 
 def worker_status(request: Request) -> JsonResponse:

--- a/chirps/worker/views.py
+++ b/chirps/worker/views.py
@@ -10,7 +10,10 @@ def worker_status(request: Request) -> JsonResponse:
     """Get the status of the Celery worker"""
     celery_inspection = app.control.inspect()
     celery_statuses = celery_inspection.ping()
-    is_celery_running = all(v['ok'] == 'pong' for k, v in celery_statuses.items())
+
+    is_celery_running = False
+    if celery_statuses:
+        is_celery_running = all(v['ok'] == 'pong' for v in celery_statuses.values())
 
     is_rabbit_running = os.system('rabbitmqctl ping') == 0
 

--- a/chirps/worker/views.py
+++ b/chirps/worker/views.py
@@ -11,12 +11,15 @@ from chirps.celery import app
 def is_redis_running() -> bool:
     """Check redis status"""
     cmd = 'docker-compose -f /workspace/.devcontainer/docker-compose.yml ps | grep redis'
-    result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, text=True)
-
-    if result.returncode == 0 and 'redis' in result.stdout and 'Up' in result.stdout:
-        return True
-    else:
+    try:
+        result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, text=True)
+    except Exception:
         return False
+    else:
+        if result.returncode == 0 and 'redis' in result.stdout and 'Up' in result.stdout:
+            return True
+        else:
+            return False
 
 
 def worker_status(request: Request) -> JsonResponse:

--- a/chirps/worker/views.py
+++ b/chirps/worker/views.py
@@ -1,0 +1,18 @@
+from django.http import HttpResponse
+
+from chirps.celery import app
+
+
+def worker_status(request):
+    """Get the worker's status"""
+    inspection = app.control.inspect()  # Use app.control.inspect() instead of app.inspect()
+    result = inspection.ping()
+
+    if result:
+        color = 'green'
+    else:
+        color = 'red'
+
+    return HttpResponse(
+        f'<div style="display: inline-block; width: 15px; height: 15px; border-radius: 50%; background-color: {color};"></div>'
+    )

--- a/chirps/worker/views.py
+++ b/chirps/worker/views.py
@@ -13,7 +13,7 @@ def is_redis_running() -> bool:
     cmd = 'docker-compose -f /workspace/.devcontainer/docker-compose.yml ps | grep redis'
     try:
         result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, text=True, check=True)
-    except Exception:   # type: ignore
+    except subprocess.CalledProcessError:
         return False
 
     if result.returncode == 0 and 'redis' in result.stdout and 'Up' in result.stdout:

--- a/chirps/worker/views.py
+++ b/chirps/worker/views.py
@@ -1,3 +1,4 @@
+"""Worker application views"""
 import os
 
 from django.http import JsonResponse

--- a/mypy.ini
+++ b/mypy.ini
@@ -10,3 +10,6 @@ ignore_missing_imports = True
 
 [mypy-mantium_spec.*]
 ignore_missing_imports = True
+
+[mypy-chirps.*]
+ignore_missing_imports = True


### PR DESCRIPTION
The purpose of this PR is to add a worker status indicator to the nav bar. We poll the `/worker/status` API endpoint every 5 seconds and return the statuses. The indicator is green when celery and rabbitmq are running, and it's red if either of them are not running. Clicking on the indicator opens a modal with details.

![Aug-14-2023 12-23-13](https://github.com/mantiumai/chirps/assets/48630278/daee959b-56e1-46a6-bfae-4db0bfe5c9b2)
