### PR TITLE
make workspace directory dynamic

### DIFF
--- a/chirps/base_app/management/commands/redis.py
+++ b/chirps/base_app/management/commands/redis.py
@@ -1,6 +1,7 @@
 """Management command for interacting with redis."""
 import os
 
+from chirps.settings import BASE_DIR
 from django.core.management.base import BaseCommand
 
 
@@ -17,7 +18,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         """Handle redis command"""
-        workspace_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..', ".."))
+        workspace_path = os.path.abspath(os.path.join(BASE_DIR, '..'))
         if options['start']:
             os.system(f'docker-compose -f {workspace_path}/.devcontainer/docker-compose.yml up -d redis')
         elif options['stop']:

--- a/chirps/base_app/management/commands/redis.py
+++ b/chirps/base_app/management/commands/redis.py
@@ -1,8 +1,9 @@
 """Management command for interacting with redis."""
 import os
 
-from chirps.settings import BASE_DIR
 from django.core.management.base import BaseCommand
+
+from chirps.settings import BASE_DIR
 
 
 class Command(BaseCommand):

--- a/chirps/base_app/management/commands/redis.py
+++ b/chirps/base_app/management/commands/redis.py
@@ -17,9 +17,10 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         """Handle redis command"""
+        workspace_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..', ".."))
         if options['start']:
-            os.system('docker-compose -f /workspace/.devcontainer/docker-compose.yml up -d redis')
+            os.system(f'docker-compose -f {workspace_path}/.devcontainer/docker-compose.yml up -d redis')
         elif options['stop']:
-            os.system('docker-compose -f /workspace/.devcontainer/docker-compose.yml down')
+            os.system(f'docker-compose -f {workspace_path}/.devcontainer/docker-compose.yml down')
         elif options['status']:
-            os.system('docker-compose -f /workspace/.devcontainer/docker-compose.yml ps')
+            os.system(f'docker-compose -f {workspace_path}/.devcontainer/docker-compose.yml ps')


### PR DESCRIPTION
I tried running
```
./chirps/manage.py initialize_app
```
but encountered 
```
ERROR: .FileNotFoundError: [Errno 2] No such file or directory: '/workspace/.devcontainer/docker-compose.yml'
```
Haven't worked much with Django, but the ```pip install -r requirements.txt``` installed everything without errors. The next command seems to make an assumption there is "/workspace" dir, but there wasn't one on my machine. My "workspace" is called "chirps" and it was a couple of directories down from the root dir. This change takes way any workspace naming and location assumptions by climbing up the path from the current redis.py file.