### PR TITLE
Css update - Table fixed width for policies

### DIFF
--- a/chirps/policy/templates/policy/dashboard_policy_list.html
+++ b/chirps/policy/templates/policy/dashboard_policy_list.html
@@ -15,8 +15,9 @@
     <div id="collapse-{{policy.id}}" class="accordion-collapse collapse">
         <div class="accordion-body">
             <h5>Rules</h5>
-            <table class="table">
-                <thead>
+            <div class="table-responsive">
+                <table class="table" style="width: 100%;">
+                    <thead>
                     <tr>
                         <th scope="col">Name</th>
                         <th scope="col">Description</th>
@@ -39,6 +40,7 @@
                 </tbody>
             </table>
         </div>
+    </div>
 
         {% if edit_mode %}
         {% if policy.is_template == False %}

--- a/chirps/policy/templates/policy/dashboard_policy_list.html
+++ b/chirps/policy/templates/policy/dashboard_policy_list.html
@@ -15,9 +15,8 @@
     <div id="collapse-{{policy.id}}" class="accordion-collapse collapse">
         <div class="accordion-body">
             <h5>Rules</h5>
-            <div class="table-responsive">
-                <table class="table" style="width: 100%;">
-                    <thead>
+            <table class="table">
+                <thead>
                     <tr>
                         <th scope="col">Name</th>
                         <th scope="col">Description</th>
@@ -30,17 +29,36 @@
                 <tbody>
                 {% for rule in policy.current_version.rules.all %}
                 <tr>
-                    <td style="word-wrap: break-word; max-width: 100%;">{{rule.name}}</td>
-                    <td style="word-wrap: break-word; max-width: 100%;">{{rule.description}}</td>
-                    <td style="word-wrap: break-word; max-width: 100%;">{{rule.query_string}}</td>
-                    <td style="word-wrap: break-word; max-width: 100%;">{{rule.regex_test}}</td>
-                    <td style="word-wrap: break-word; max-width: 100%;">{{rule.severity}}</td>
+                    <td>
+                        <span class="d-inline-block" tabindex="0" data-toggle="tooltip" title="{{rule.name}}">
+                            {{rule.name|truncatechars:50}}
+                        </span>
+                    </td>
+                    <td>
+                        <span class="d-inline-block" tabindex="0" data-toggle="tooltip" title="{{rule.description}}">
+                            {{rule.description|truncatechars:50}}
+                        </span>
+                    </td>
+                    <td>
+                        <span class="d-inline-block" tabindex="0" data-toggle="tooltip" title="{{rule.query_string}}">
+                            {{rule.query_string|truncatechars:50}}
+                        </span>
+                    </td>
+                    <td>
+                        <span class="d-inline-block" tabindex="0" data-toggle="tooltip" title="{{rule.regex_test}}">
+                            {{rule.regex_test|truncatechars:50}}
+                        </span>
+                    </td>
+                    <td>
+                        <span class="d-inline-block" tabindex="0" data-toggle="tooltip" title="{{rule.severity}}">
+                            {{rule.severity|truncatechars:50}}
+                        </span>
+                    </td>
                 </tr>
                 {% endfor %}
                 </tbody>
             </table>
         </div>
-    </div>
 
         {% if edit_mode %}
         {% if policy.is_template == False %}

--- a/chirps/policy/templates/policy/dashboard_policy_list.html
+++ b/chirps/policy/templates/policy/dashboard_policy_list.html
@@ -32,7 +32,7 @@
                     <td>{{rule.name}}</td>
                     <td>{{rule.description}}</td>
                     <td>{{rule.query_string}}</td>
-                    <td>{{rule.regex_test}}</td>
+                    <td style="word-wrap: break-word; max-width: 100%;">{{rule.regex_test}}</td>
                     <td>{{rule.severity}}</td>
                 </tr>
                 {% endfor %}

--- a/chirps/policy/templates/policy/dashboard_policy_list.html
+++ b/chirps/policy/templates/policy/dashboard_policy_list.html
@@ -29,11 +29,11 @@
                 <tbody>
                 {% for rule in policy.current_version.rules.all %}
                 <tr>
-                    <td>{{rule.name}}</td>
-                    <td>{{rule.description}}</td>
-                    <td>{{rule.query_string}}</td>
+                    <td style="word-wrap: break-word; max-width: 100%;">{{rule.name}}</td>
+                    <td style="word-wrap: break-word; max-width: 100%;">{{rule.description}}</td>
+                    <td style="word-wrap: break-word; max-width: 100%;">{{rule.query_string}}</td>
                     <td style="word-wrap: break-word; max-width: 100%;">{{rule.regex_test}}</td>
-                    <td>{{rule.severity}}</td>
+                    <td style="word-wrap: break-word; max-width: 100%;">{{rule.severity}}</td>
                 </tr>
                 {% endfor %}
                 </tbody>


### PR DESCRIPTION
# Description
This was a minor update to the CSS to make the policies table a fixed width. For text that would normally go outside, there is now a slider.

# Problem
Previously, some of the text in the body of the table under the accordion would span outside of the "box"

![image](https://github.com/mantiumai/chirps/assets/86671951/11818118-7e2a-4325-8de6-34ee513ce0c7)

# Solution
By implementing these changes, the entire object is still viewable but it remains in the constraints which is more visually appealing and therefore a better UX. A slider can be used to scroll through the overflowed text

![image](https://github.com/mantiumai/chirps/assets/86671951/5536def9-10ef-444e-bdfa-ee32529ad11f)
