### PR TITLE
Add auto restart for celery

### DIFF
--- a/chirps/base_app/management/commands/celery.py
+++ b/chirps/base_app/management/commands/celery.py
@@ -2,6 +2,7 @@
 import os
 
 from django.core.management.base import BaseCommand
+from django.utils import autoreload
 
 
 class Command(BaseCommand):
@@ -18,12 +19,13 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         """Handle the command."""
         if options['start']:
-            self.start()
+            self.stop()
+            autoreload.run_with_reloader(self.start)
         elif options['stop']:
             self.stop()
         elif options['restart']:
             self.stop()
-            self.start()
+            autoreload.run_with_reloader(self.start)
 
     def start(self):
         """Start the celery server."""


### PR DESCRIPTION
### Fix for Issue #20

- Used Django's autoreload to detect changes and restart Celery.
- Added step to stop Celery before a regular start due to the directory `/var/run/celery` not being removed on reload.