### PR TITLE
Revert "Add auto restart for celery"

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ The chirps application makes use of Celery and RabbitMQ for job processing. Exec
 
 Both the rabbitmq and celery commands have `--stop` and `--restart` options as well.
 
+#### IMPORTANT CELERY TIP
+
+If you make changes to a Celery task, it must be restarted in order for those changes to be picked up. Simply run
+`./manage.py celery --restart`
+
 ### Run Webserver
 
 `./manage.py runserver`

--- a/chirps/base_app/management/commands/celery.py
+++ b/chirps/base_app/management/commands/celery.py
@@ -2,7 +2,6 @@
 import os
 
 from django.core.management.base import BaseCommand
-from django.utils import autoreload
 
 
 class Command(BaseCommand):
@@ -19,13 +18,12 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         """Handle the command."""
         if options['start']:
-            self.stop()
-            autoreload.run_with_reloader(self.start)
+            self.start()
         elif options['stop']:
             self.stop()
         elif options['restart']:
             self.stop()
-            autoreload.run_with_reloader(self.start)
+            self.start()
 
     def start(self):
         """Start the celery server."""


### PR DESCRIPTION
Reverts mantiumai/chirps#170

Reverting this PR since the functionality blocks when `./manage.py celery --start` is invoked. Not quite what we're looking for. 