### PR TITLE
update policy dashboard template to group rules by type

### DIFF
--- a/chirps/policy/templates/policy/dashboard_policy_list.html
+++ b/chirps/policy/templates/policy/dashboard_policy_list.html
@@ -18,7 +18,7 @@
             {% with grouped_rules=policy.current_version.rules.all|group_by_rule_type %}
             {% for rule_type, rules in grouped_rules.items %}
             {% if rule_type == 'regex' and rules %}
-            <h6>Regex Rules</h6>
+            <h5>Regex Rules</h5>
             <table class="table">
                 <thead>
                     <tr>
@@ -58,7 +58,7 @@
             </table>
 
             {% elif rule_type == 'multiquery' and rules %}
-            <h6>MultiQuery Rules</h6>
+            <h5>MultiQuery Rules</h5>
             <table class="table">
                 <thead>
                     <tr>

--- a/chirps/policy/templates/policy/dashboard_policy_list.html
+++ b/chirps/policy/templates/policy/dashboard_policy_list.html
@@ -1,9 +1,9 @@
 {% for policy in policy_list %}
-<div class="accordion-item policy-row", id="chirps-policy-{{policy.id}}" hx-target="closest .policy-row" hx-swap="outerHTML">
+<div class="accordion-item policy-row" , id="chirps-policy-{{policy.id}}" hx-target="closest .policy-row"
+    hx-swap="outerHTML">
     <div class="accordion-header">
-        <button class="accordion-button collapsed" type="button"
-                data-bs-toggle="collapse" data-bs-target="#collapse-{{policy.id}}"
-                aria-expanded="false" aria-controls="collapse-{{policy.id}}">
+        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+            data-bs-target="#collapse-{{policy.id}}" aria-expanded="false" aria-controls="collapse-{{policy.id}}">
             <div class="d-flex">
                 <h5 class="ml-0 mr-3 my-auto">{{policy.name}}</h5>
                 <small class="ml-0 mr-auto my-auto">{{policy.description}}</small>
@@ -14,65 +14,110 @@
     </div>
     <div id="collapse-{{policy.id}}" class="accordion-collapse collapse">
         <div class="accordion-body">
-            <h5>Rules</h5>
+            {% load policy_filter %}
+            {% with grouped_rules=policy.current_version.rules.all|group_by_rule_type %}
+            {% for rule_type, rules in grouped_rules.items %}
+            {% if rule_type == 'regex' and rules %}
+            <h6>Regex Rules</h6>
             <table class="table">
                 <thead>
                     <tr>
                         <th scope="col">Name</th>
-                        <th scope="col">Description</th>
                         <th scope="col">Query</th>
                         <th scope="col">Test</th>
                         <th scope="col">Severity</th>
                     </tr>
                 </thead>
-
                 <tbody>
-                {% for rule in policy.current_version.rules.all %}
-                <tr>
+                    {% for rule in rules %}
+                    <tr>
+                        <td>
+                            <span class="d-inline-block" tabindex="0" data-toggle="tooltip" title="{{rule.name}}">
+                                {{rule.name|truncatechars:50}}
+                            </span>
+                        </td>
+                        <td>
+                            <span class="d-inline-block" tabindex="0" data-toggle="tooltip"
+                                title="{{rule.query_string}}">
+                                {{rule.query_string|truncatechars:50}}
+                            </span>
+                        </td>
+                        <td>
+                            <span class="d-inline-block" tabindex="0" data-toggle="tooltip" title="{{rule.regex_test}}">
+                                {{rule.regex_test|truncatechars:50}}
+                            </span>
+                        </td>
+                        <td>
+                            <span class="d-inline-block" tabindex="0" data-toggle="tooltip" title="{{rule.severity}}">
+                                {{rule.severity|truncatechars:50}}
+                            </span>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+
+            {% elif rule_type == 'multiquery' and rules %}
+            <h6>MultiQuery Rules</h6>
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th scope="col">Name</th>
+                        <th scope="col">Description</th>
+                        <th scope="col">Success Outcome</th>
+                        <th scope="col">Severity</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for rule in rules %}
                     <td>
-                        <span class="d-inline-block" tabindex="0" data-toggle="tooltip" title="{{rule.name}}">
+                        <span class="d-inline-block" tabindex="0" data-toggle="tooltip"
+                            title="{{rule.success_outcome}}">
                             {{rule.name|truncatechars:50}}
                         </span>
                     </td>
                     <td>
-                        <span class="d-inline-block" tabindex="0" data-toggle="tooltip" title="{{rule.description}}">
-                            {{rule.description|truncatechars:50}}
+                        <span class="d-inline-block" tabindex="0" data-toggle="tooltip"
+                            title="{{rule.task_description}}">
+                            {{rule.task_description|truncatechars:50}}
                         </span>
                     </td>
                     <td>
-                        <span class="d-inline-block" tabindex="0" data-toggle="tooltip" title="{{rule.query_string}}">
-                            {{rule.query_string|truncatechars:50}}
+                        <span class="d-inline-block" tabindex="0" data-toggle="tooltip"
+                            title="{{rule.success_outcome}}">
+                            {{rule.success_outcome|truncatechars:50}}
                         </span>
                     </td>
                     <td>
-                        <span class="d-inline-block" tabindex="0" data-toggle="tooltip" title="{{rule.regex_test}}">
-                            {{rule.regex_test|truncatechars:50}}
-                        </span>
-                    </td>
-                    <td>
-                        <span class="d-inline-block" tabindex="0" data-toggle="tooltip" title="{{rule.severity}}">
+                        <span class="d-inline-block" tabindex="0" data-toggle="tooltip"
+                            title="{{rule.success_outcome}}">
                             {{rule.severity|truncatechars:50}}
                         </span>
                     </td>
-                </tr>
-                {% endfor %}
+                    {% endfor %}
                 </tbody>
             </table>
+            {% endif %}
+            {% endfor %}
+            {% endwith %}
         </div>
 
         {% if edit_mode %}
         {% if policy.is_template == False %}
         <div class="row">
             <div class="col">
-                <a class="btn btn-outline-primary m-3" href="{% url 'policy_edit' policy.id %}"><i class="fa-solid fa-pen-to-square"></i> Edit</a>
-                <a href="{% url 'policy_archive' policy.id %}" class="btn btn-outline-danger m-3"><i class="fa-solid fa-trash"></i> Archive</a>
+                <a class="btn btn-outline-primary m-3" href="{% url 'policy_edit' policy.id %}"><i
+                        class="fa-solid fa-pen-to-square"></i> Edit</a>
+                <a href="{% url 'policy_archive' policy.id %}" class="btn btn-outline-danger m-3"><i
+                        class="fa-solid fa-trash"></i> Archive</a>
             </div>
             <div class="col align-self-end">
                 <p class="text-right m-3">version: {{policy.current_version.number}}</p>
             </div>
         </div>
         {% else %}
-            <a class="btn btn-outline-primary m-3" href="{% url 'policy_clone' policy.id %}"><i class="fa-solid fa-clone"></i> Clone</a>
+        <a class="btn btn-outline-primary m-3" href="{% url 'policy_clone' policy.id %}"><i
+                class="fa-solid fa-clone"></i> Clone</a>
         {% endif %}
         {% endif %}
     </div>

--- a/chirps/policy/templates/policy/dashboard_policy_list.html
+++ b/chirps/policy/templates/policy/dashboard_policy_list.html
@@ -1,3 +1,4 @@
+{% load policy_filter %}
 {% for policy in policy_list %}
 <div class="accordion-item policy-row" , id="chirps-policy-{{policy.id}}" hx-target="closest .policy-row"
     hx-swap="outerHTML">
@@ -14,7 +15,6 @@
     </div>
     <div id="collapse-{{policy.id}}" class="accordion-collapse collapse">
         <div class="accordion-body">
-            {% load policy_filter %}
             {% with grouped_rules=policy.current_version.rules.all|group_by_rule_type %}
             {% for rule_type, rules in grouped_rules.items %}
             {% if rule_type == 'regex' and rules %}

--- a/chirps/policy/templatetags/policy_filter.py
+++ b/chirps/policy/templatetags/policy_filter.py
@@ -1,0 +1,19 @@
+"""Policy template filters."""
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def group_by_rule_type(rules):
+    """Group a list of rules by their rule type."""
+    regex_rules = []
+    multiquery_rules = []
+
+    for rule in rules:
+        if rule.rule_type == 'regex':
+            regex_rules.append(rule)
+        elif rule.rule_type == 'multiquery':
+            multiquery_rules.append(rule)
+
+    return {'regex': regex_rules, 'multiquery': multiquery_rules}


### PR DESCRIPTION
The purpose of this PR is to display policy rules in groups by type. Different rule types have different attributes, so the rule headers should reflect this.

![Screenshot 2023-09-06 at 3 42 53 PM](https://github.com/mantiumai/chirps/assets/48630278/bd37ecaa-8543-4b69-8c89-e7adf7361d6e)
