### PR TITLE
fix MultiQueryRule policy clone bug

### DIFF
--- a/chirps/policy/templates/policy/dashboard_policy_list.html
+++ b/chirps/policy/templates/policy/dashboard_policy_list.html
@@ -70,30 +70,32 @@
                 </thead>
                 <tbody>
                     {% for rule in rules %}
-                    <td>
-                        <span class="d-inline-block" tabindex="0" data-toggle="tooltip"
-                            title="{{rule.success_outcome}}">
-                            {{rule.name|truncatechars:50}}
-                        </span>
-                    </td>
-                    <td>
-                        <span class="d-inline-block" tabindex="0" data-toggle="tooltip"
-                            title="{{rule.task_description}}">
-                            {{rule.task_description|truncatechars:50}}
-                        </span>
-                    </td>
-                    <td>
-                        <span class="d-inline-block" tabindex="0" data-toggle="tooltip"
-                            title="{{rule.success_outcome}}">
-                            {{rule.success_outcome|truncatechars:50}}
-                        </span>
-                    </td>
-                    <td>
-                        <span class="d-inline-block" tabindex="0" data-toggle="tooltip"
-                            title="{{rule.success_outcome}}">
-                            {{rule.severity|truncatechars:50}}
-                        </span>
-                    </td>
+                    <tr>
+                        <td>
+                            <span class="d-inline-block" tabindex="0" data-toggle="tooltip"
+                                title="{{rule.name}}">
+                                {{rule.name|truncatechars:50}}
+                            </span>
+                        </td>
+                        <td>
+                            <span class="d-inline-block" tabindex="0" data-toggle="tooltip"
+                                title="{{rule.task_description}}">
+                                {{rule.task_description|truncatechars:50}}
+                            </span>
+                        </td>
+                        <td>
+                            <span class="d-inline-block" tabindex="0" data-toggle="tooltip"
+                                title="{{rule.success_outcome}}">
+                                {{rule.success_outcome|truncatechars:50}}
+                            </span>
+                        </td>
+                        <td>
+                            <span class="d-inline-block" tabindex="0" data-toggle="tooltip"
+                                title="{{rule.severity}}">
+                                {{rule.severity|truncatechars:50}}
+                            </span>
+                        </td>
+                    </tr>
                     {% endfor %}
                 </tbody>
             </table>

--- a/chirps/policy/views.py
+++ b/chirps/policy/views.py
@@ -120,14 +120,25 @@ def clone(request, policy_id):
 
     # Clone the rules
     for rule in policy.current_version.rules.all():
-        save_rule(
-            rule.rule_type,
-            name=rule.name,
-            query_string=rule.query_string,
-            regex_test=rule.regex_test,
-            severity=rule.severity,
-            policy=policy_version,
-        )
+        if rule.rule_type == 'regex':
+            save_rule(
+                rule.rule_type,
+                name=rule.name,
+                query_string=rule.query_string,
+                regex_test=rule.regex_test,
+                severity=rule.severity,
+                policy=policy_version,
+            )
+        elif rule.rule_type == 'multiquery':
+            save_rule(
+                rule.rule_type,
+                name=rule.name,
+                task_description=rule.task_description,
+                success_outcome=rule.success_outcome,
+                attack_count=rule.attack_count,
+                severity=rule.severity,
+                policy=policy_version,
+            )
 
     # Redirect to the edit page for the new policy
     return redirect('policy_edit', policy_id=cloned_policy.id)


### PR DESCRIPTION
The purpose of this PR is to fix two bugs: 
- Policy cloning fails when the policy contains a `MultiQueryRule`
- Multiple `MultiQueryRule`s within a policy displaying in line instead of as table rows