### PR TITLE
implement APIEndpointAsset ping functionality

### DIFF
--- a/chirps/asset/models.py
+++ b/chirps/asset/models.py
@@ -39,7 +39,9 @@ class BaseAsset(PolymorphicModel):
 
     def scan_is_active(self) -> bool:
         """Return True if the asset is currently being scanned."""
-        return self.scan_run_assets.filter(~Q(scan__status='Complete')).exists()
+        return self.scan_run_assets.filter(
+            ~Q(scan__status='Complete') & ~Q(scan__status='Failed') & ~Q(scan__status='Canceled')
+        ).exists()
 
     def search(self, query: str, max_results: int) -> list[SearchResult]:
         """Perform a query against the specified asset, returning the max_results number of matches."""

--- a/chirps/asset/providers/api_endpoint.py
+++ b/chirps/asset/providers/api_endpoint.py
@@ -69,24 +69,6 @@ class APIEndpointAsset(BaseAsset):
 
     def fetch_api_data(self, query: str) -> dict:
         """Fetch data from the API using the provided query."""
-        # # Convert headers JSON string into a dictionary
-        # headers_dict = json.loads(self.headers) if self.headers else {}
-
-        # # Build the request headers
-        # headers = headers_dict.copy()
-        # if self.authentication_method == 'Bearer':
-        #     headers['Authorization'] = f'Bearer {self.api_key}'
-        # elif self.authentication_method == 'Basic':
-        #     headers['Authorization'] = f'Basic {self.api_key}'
-
-        # # Replace the %query% placeholder in the body
-        # body = json.loads(json.dumps(self.body).replace('%query%', query))
-
-        # # Send the request
-        # try:
-        #     response = requests.post(self.url, headers=headers, json=body, timeout=self.timeout)
-        # except Timeout as exc:
-        #     raise RequestException('Error: API request timed out') from exc
         response = self._send_request(query)
 
         # Check if the request was successful
@@ -99,25 +81,7 @@ class APIEndpointAsset(BaseAsset):
 
     def test_connection(self) -> PingResult:
         """Ensure that the API Endpoint asset can be connected to."""
-        # # Convert headers JSON string into a dictionary
-        # headers_dict = json.loads(self.headers) if self.headers else {}
-
-        # # Build the request headers
-        # headers = headers_dict.copy()
-        # if self.authentication_method == 'Bearer':
-        #     headers['Authorization'] = f'Bearer {self.api_key}'
-        # elif self.authentication_method == 'Basic':
-        #     headers['Authorization'] = f'Basic {self.api_key}'
-
-        # # Replace the %query% placeholder in the body
         message = 'Test message'
-        # body = json.loads(json.dumps(self.body).replace('%query%', message))
-
-        # # Send the request
-        # try:
-        #     response = requests.post(self.url, headers=headers, json=body, timeout=self.timeout)
-        # except RequestException as exc:
-        #     return PingResult(success=False, error=f'Error: {str(exc)}')
         response = self._send_request(message)
 
         # Check if the request was successful and return a PingResult object

--- a/chirps/asset/providers/api_endpoint.py
+++ b/chirps/asset/providers/api_endpoint.py
@@ -86,9 +86,13 @@ class APIEndpointAsset(BaseAsset):
         elif self.authentication_method == 'Basic':
             headers['Authorization'] = f'Basic {self.api_key}'
 
+        # Replace the %query% placeholder in the body
+        message = 'Test message'
+        body = json.loads(json.dumps(self.body).replace('%query%', message))
+
         # Send the request
         try:
-            response = requests.post(self.url, headers=headers, timeout=self.timeout)
+            response = requests.post(self.url, headers=headers, json=body, timeout=self.timeout)
         except RequestException as exc:
             return PingResult(success=False, error=f'Error: {str(exc)}')
 

--- a/chirps/asset/providers/api_endpoint.py
+++ b/chirps/asset/providers/api_endpoint.py
@@ -45,8 +45,7 @@ class APIEndpointAsset(BaseAsset):
                 return 'Error: Decryption failed'
         return None
 
-    def fetch_api_data(self, query: str) -> dict:
-        """Fetch data from the API using the provided query."""
+    def _send_request(self, message: str) -> requests.Response:
         # Convert headers JSON string into a dictionary
         headers_dict = json.loads(self.headers) if self.headers else {}
 
@@ -58,13 +57,37 @@ class APIEndpointAsset(BaseAsset):
             headers['Authorization'] = f'Basic {self.api_key}'
 
         # Replace the %query% placeholder in the body
-        body = json.loads(json.dumps(self.body).replace('%query%', query))
+        body = json.loads(json.dumps(self.body).replace('%query%', message))
 
         # Send the request
         try:
             response = requests.post(self.url, headers=headers, json=body, timeout=self.timeout)
         except Timeout as exc:
             raise RequestException('Error: API request timed out') from exc
+
+        return response
+
+    def fetch_api_data(self, query: str) -> dict:
+        """Fetch data from the API using the provided query."""
+        # # Convert headers JSON string into a dictionary
+        # headers_dict = json.loads(self.headers) if self.headers else {}
+
+        # # Build the request headers
+        # headers = headers_dict.copy()
+        # if self.authentication_method == 'Bearer':
+        #     headers['Authorization'] = f'Bearer {self.api_key}'
+        # elif self.authentication_method == 'Basic':
+        #     headers['Authorization'] = f'Basic {self.api_key}'
+
+        # # Replace the %query% placeholder in the body
+        # body = json.loads(json.dumps(self.body).replace('%query%', query))
+
+        # # Send the request
+        # try:
+        #     response = requests.post(self.url, headers=headers, json=body, timeout=self.timeout)
+        # except Timeout as exc:
+        #     raise RequestException('Error: API request timed out') from exc
+        response = self._send_request(query)
 
         # Check if the request was successful
         if response.status_code != 200:
@@ -76,38 +99,39 @@ class APIEndpointAsset(BaseAsset):
 
     def test_connection(self) -> PingResult:
         """Ensure that the API Endpoint asset can be connected to."""
-        # Convert headers JSON string into a dictionary
-        headers_dict = json.loads(self.headers) if self.headers else {}
+        # # Convert headers JSON string into a dictionary
+        # headers_dict = json.loads(self.headers) if self.headers else {}
 
-        # Build the request headers
-        headers = headers_dict.copy()
-        if self.authentication_method == 'Bearer':
-            headers['Authorization'] = f'Bearer {self.api_key}'
-        elif self.authentication_method == 'Basic':
-            headers['Authorization'] = f'Basic {self.api_key}'
+        # # Build the request headers
+        # headers = headers_dict.copy()
+        # if self.authentication_method == 'Bearer':
+        #     headers['Authorization'] = f'Bearer {self.api_key}'
+        # elif self.authentication_method == 'Basic':
+        #     headers['Authorization'] = f'Basic {self.api_key}'
 
-        # Replace the %query% placeholder in the body
+        # # Replace the %query% placeholder in the body
         message = 'Test message'
-        body = json.loads(json.dumps(self.body).replace('%query%', message))
+        # body = json.loads(json.dumps(self.body).replace('%query%', message))
 
-        # Send the request
-        try:
-            response = requests.post(self.url, headers=headers, json=body, timeout=self.timeout)
-        except RequestException as exc:
-            return PingResult(success=False, error=f'Error: {str(exc)}')
+        # # Send the request
+        # try:
+        #     response = requests.post(self.url, headers=headers, json=body, timeout=self.timeout)
+        # except RequestException as exc:
+        #     return PingResult(success=False, error=f'Error: {str(exc)}')
+        response = self._send_request(message)
 
         # Check if the request was successful and return a PingResult object
         if response.status_code == 200:
             return PingResult(success=True)
-        else:
-            try:
-                response_data = response.json()
-                error_message = json.dumps(response_data, indent=2)
-            except ValueError:
-                error_message = response.text
 
-            error = f'Error: API request failed with status code {response.status_code} and response:\n{error_message}'
-            return PingResult(success=False, error=error)
+        try:
+            response_data = response.json()
+            error_message = json.dumps(response_data, indent=2)
+        except ValueError:
+            error_message = response.text
+
+        error = f'Error: API request failed with status code {response.status_code} and response:\n{error_message}'
+        return PingResult(success=False, error=error)
 
     def displayable_attributes(self):
         """Display a subset of the model's attributes"""

--- a/chirps/asset/tests.py
+++ b/chirps/asset/tests.py
@@ -300,11 +300,8 @@ class APIEndpointAssetTests(TestCase):
 
     def test_test_connection(self):
         """Test the test_connection method."""
-        mock_response_data = {'message': 'Connection successful'}
-
         with mock.patch('requests.post') as mock_post:
             mock_post.return_value.status_code = 200
-            mock_post.return_value.json.return_value = mock_response_data
 
             ping_result = self.api_endpoint_asset.test_connection()
             self.assertIsInstance(ping_result, PingResult)

--- a/chirps/asset/tests.py
+++ b/chirps/asset/tests.py
@@ -314,8 +314,9 @@ class APIEndpointAssetTests(TestCase):
             expected_url = self.api_endpoint_asset.url
             expected_headers = json.loads(self.api_endpoint_asset.headers)
             expected_headers['Authorization'] = f'Bearer {self.api_endpoint_asset.api_key}'
+            expected_body = self.api_endpoint_asset.body.replace('%query%', 'Test message')
 
-            mock_post.assert_called_once_with(expected_url, headers=expected_headers, timeout=30)
+            mock_post.assert_called_once_with(expected_url, headers=expected_headers, json=expected_body, timeout=30)
 
     def test_test_connection_failure(self):
         """Test the test_connection method when the API request fails."""
@@ -333,5 +334,6 @@ class APIEndpointAssetTests(TestCase):
             expected_url = self.api_endpoint_asset.url
             expected_headers = json.loads(self.api_endpoint_asset.headers)
             expected_headers['Authorization'] = f'Bearer {self.api_endpoint_asset.api_key}'
+            expected_body = self.api_endpoint_asset.body.replace('%query%', 'Test message')
 
-            mock_post.assert_called_once_with(expected_url, headers=expected_headers, timeout=30)
+            mock_post.assert_called_once_with(expected_url, headers=expected_headers, json=expected_body, timeout=30)

--- a/chirps/asset/tests.py
+++ b/chirps/asset/tests.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import fakeredis
 from asset.forms import APIEndpointAssetForm, PineconeAssetForm, RedisAssetForm
+from asset.models import PingResult
 from asset.providers.api_endpoint import APIEndpointAsset
 from asset.providers.mantium import MantiumAsset
 from asset.providers.redis import RedisAsset
@@ -296,3 +297,41 @@ class APIEndpointAssetTests(TestCase):
             self.assertEqual(result['avatarFormat'], 'webm')
             self.assertEqual(result['secure'], 'true')
             self.assertEqual(result['message'], 'hello')
+
+    def test_test_connection(self):
+        """Test the test_connection method."""
+        mock_response_data = {'message': 'Connection successful'}
+
+        with mock.patch('requests.post') as mock_post:
+            mock_post.return_value.status_code = 200
+            mock_post.return_value.json.return_value = mock_response_data
+
+            ping_result = self.api_endpoint_asset.test_connection()
+            self.assertIsInstance(ping_result, PingResult)
+            self.assertTrue(ping_result.success)
+            self.assertIsNone(ping_result.error)
+
+            expected_url = self.api_endpoint_asset.url
+            expected_headers = json.loads(self.api_endpoint_asset.headers)
+            expected_headers['Authorization'] = f'Bearer {self.api_endpoint_asset.api_key}'
+
+            mock_post.assert_called_once_with(expected_url, headers=expected_headers, timeout=30)
+
+    def test_test_connection_failure(self):
+        """Test the test_connection method when the API request fails."""
+        mock_response_data = {'error': 'API request failed'}
+
+        with mock.patch('requests.post') as mock_post:
+            mock_post.return_value.status_code = 400
+            mock_post.return_value.json.return_value = mock_response_data
+
+            ping_result = self.api_endpoint_asset.test_connection()
+            self.assertIsInstance(ping_result, PingResult)
+            self.assertFalse(ping_result.success)
+            self.assertIn(mock_response_data['error'], ping_result.error)
+
+            expected_url = self.api_endpoint_asset.url
+            expected_headers = json.loads(self.api_endpoint_asset.headers)
+            expected_headers['Authorization'] = f'Bearer {self.api_endpoint_asset.api_key}'
+
+            mock_post.assert_called_once_with(expected_url, headers=expected_headers, timeout=30)


### PR DESCRIPTION
The purpose of this PR is to make the APIEndpointAsset's ping button work. It'll work by making a request using the information provided by the user when creating the asset, and we'll return True if the response status code is 200, False otherwise.

I noticed that this asset's edit button was disabled even when I had no scans running. We were disabling the button if there was a scan associated with the asset and that scan was not in 'Completed' state. We have more terminal states than just 'Completed', so I've updated the query to filter on those other states as well.

In addition to the tests added in this PR, I've manually confirmed that the ping button now works.